### PR TITLE
Deploy script + New chains

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,14 +105,18 @@ Thus, the actual memory of the host is starting at either 0x340 or 0x460 dependi
 
 ## Addresses
 
-Deployed at 0xdb4516887ccd9a593e390f6a43e34494a524a551 on:
+Deployed at `0x36dAc1C6a72F94C13369Db9DAdCBD79ba5425019` on:
 
-- [Ethereum](https://etherscan.io/address/0xdb4516887ccd9a593e390f6a43e34494a524a551#code)
-- [Polygon](https://polygonscan.com/address/0xdb4516887ccd9a593e390f6a43e34494a524a551#code)
-- [Arbitrum](https://arbiscan.io/address/0xdb4516887ccd9a593e390f6a43e34494a524a551#code )
-- [Avalanche](https://snowtrace.io/address/0xdb4516887ccd9a593e390f6a43e34494a524a551#code )
-- [Optimism](https://optimistic.etherscan.io/address/0xdb4516887ccd9a593e390f6a43e34494a524a551#code)
-- [Goerli](https://goerli.etherscan.io/address/0xdb4516887ccd9a593e390f6a43e34494a524a551#code)
+- [Ethereum](https://etherscan.io/address/0x36dac1c6a72f94c13369db9dadcbd79ba5425019#code)
+- [Polygon](https://polygonscan.com/address/0x36dac1c6a72f94c13369db9dadcbd79ba5425019#code)
+- [BNB Chain](https://bscscan.com/address/0x36dac1c6a72f94c13369db9dadcbd79ba5425019#code)
+- [Arbitrum](https://arbiscan.io/address/0x36dac1c6a72f94c13369db9dadcbd79ba5425019#code )
+- [Avalanche](https://snowtrace.io/address/0x36dac1c6a72f94c13369db9dadcbd79ba5425019#code )
+- [Optimism](https://optimistic.etherscan.io/address/0x36dac1c6a72f94c13369db9dadcbd79ba5425019#code)
+- [Fantom](https://ftmscan.com/address/0x36dac1c6a72f94c13369db9dadcbd79ba5425019#code)
+- [Aurora](https://aurorascan.dev/address/0x36dac1c6a72f94c13369db9dadcbd79ba5425019#code)
+- [Goerli](https://goerli.etherscan.io/address/0x36dac1c6a72f94c13369db9dadcbd79ba5425019#code)
+- [Sepolia](https://sepolia.etherscan.io/address/0x36dac1c6a72f94c13369db9dadcbd79ba5425019#code)
 
 ## Getting Started
 

--- a/script/Deploy.s.sol
+++ b/script/Deploy.s.sol
@@ -1,37 +1,45 @@
 // SPDX-License-Identifier: Unlicense
 pragma solidity ^0.8.15;
 
-import "foundry-huff/HuffDeployer.sol";
 import "forge-std/Script.sol";
+import "foundry-huff/HuffDeployer.sol";
 
-interface SimpleStore {
-  function setValue(uint256) external;
-  function getValue() external returns (uint256);
-}
-
+/// @notice Deploy the HyVM using CREATE2
 contract Deploy is Script {
-  function run() public returns (address deployedAddress) {
+    // The address is the same on all EVM chains.
+    Deployer public constant DEPLOYER = Deployer(0x13b0D85CcB8bf860b6b79AF3029fCA081AE9beF2);
+
+    function run() public returns (address deployedAddress) {
         string memory bashCommand = 'cast abi-encode "f(bytes)" $(huffc ./src/HyVM.huff --bytecode | head)';
 
         string[] memory inputs = new string[](3);
         inputs[0] = "bash";
         inputs[1] = "-c";
         inputs[2] = bashCommand;
+
         bytes memory bytecode = abi.decode(vm.ffi(inputs), (bytes));
+        bytes32 salt = keccak256("HyVM");
+
+        deployedAddress = DEPLOYER.computeAddress(salt, keccak256(bytecode));
 
         vm.startBroadcast();
-        assembly {
-            deployedAddress := create(0, add(bytecode, 0x20), mload(bytecode))
-        }
 
-        ///@notice check that the deployment was successful
-        require(
-            deployedAddress != address(0),
-            "HuffDeployer could not deploy contract"
-        );
+        // Call CREATE2 Deployer
+        DEPLOYER.deploy(0, salt, bytecode);
+
+        // Check if contract deployed at expected address
+        require(deployedAddress.code.length > 0, "HyVM not deployed");
 
         vm.stopBroadcast();
-        // console.log("Deployed at ", deployedAddress);
+
         return deployedAddress;
-  }
+    }
+}
+
+// Create2 Deployer Interface
+// https://github.com/pcaversaccio/create2deployer
+interface Deployer {
+    function deploy(uint256 value, bytes32 salt, bytes memory code) external;
+
+    function computeAddress(bytes32 salt, bytes32 codeHash) external returns (address);
 }


### PR DESCRIPTION
The deploy script now use CREATE2 with [create2deployer](https://github.com/pcaversaccio/create2deployer).

New chains are available : 
- BNB Chain
- Aurora
- Sepolia

New HyVM address (`0x36dAc1C6a72F94C13369Db9DAdCBD79ba5425019`) including:
- #4 
- #5 

