### PR TITLE
fix: bump huffc and remove workaround

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,7 +124,9 @@ Deployed at `0xCB70efa43300Cd9B7eF4ed2087ceA7f7f6f3c195` on:
 ## Getting Started
 
 You will need:
-* [Huff](https://docs.huff.sh/get-started/installing/)
+* [Huff](https://docs.huff.sh/get-started/installing/) (`huffc 0.3.1` / `nightly-94c34e402a46365fee29863aa08558af178c2b94`)  
+This is the last version with which the HyVM was tested.
+It is not possible to pin the Huffc version in CI consistently as pre-released versions are pruned and only the 3 newest nightlies are kept. So it is not pinned in CI.
 * [Foundry/Forge](https://github.com/foundry-rs/foundry)
 
 You can find `easm`, the basic EVM assembly compiler that is used to compile tests [here](https://github.com/oguimbal/EVM-Assembler).  

--- a/foundry.toml
+++ b/foundry.toml
@@ -10,6 +10,8 @@ remappings = [
   "forge-std=lib/forge-std/src/",
   "foundry-huff=lib/foundry-huff/src/",
 ]
+fork_block_number = 17024124 # pin block number for forked tests
+
 [profile.default.rpc_endpoints]
 eth = 'https://eth-mainnet.g.alchemy.com/v2/${ALCHEMY_KEY}'
 arbi = 'https://arb-mainnet.g.alchemy.com/v2/${ALCHEMY_KEY_ARBITRUM}'

--- a/src/HyVM.huff
+++ b/src/HyVM.huff
@@ -24,11 +24,7 @@
 #define macro CONSTRUCTOR() = takes (0) returns (0) {
     // store address of HyVM contract at the end of the runtimecode
     // memory position at construction time.
-    // It seems __codesize(CONSTRUCTOR) does not take into account 2 bytes
-    // hence we fix it manually
-    0x02                      // [0x02]
-    __codesize(CONSTRUCTOR)   // [__codesize(CONSTRUCTOR), 0x02]
-    add                       // [offset]
+    __codesize(CONSTRUCTOR)   // [offset]
     dup1                      // [offset, offset]
     dup1                      // [offset, offset, offset]
     address                   // [address(this), offset, offset, offset]

--- a/test/forked/GMX.fork.t.sol
+++ b/test/forked/GMX.fork.t.sol
@@ -23,7 +23,7 @@ contract GMXTest is Test {
     // PositionRouter
     IGMXPositionRouter positionRouter = IGMXPositionRouter(0xb87a436B93fFE9D75c5cFA7bAcFff96430b09868);
     // Admin of the Position Router
-    address positionRouterAdmin = address(0x5F799f365Fa8A2B60ac0429C48B153cA5a6f0Cf8);
+    address positionRouterAdmin = address(0xB4d2603B2494103C90B2c607261DD85484b49eF0);
 
     //  =====   Set up  =====
     function setUp() public {


### PR DESCRIPTION
This PR removes the workaround introduced by https://github.com/oguimbal/HyVM/pull/26 as it was fixed in new version of Huff compiler.

Side note: GMX tests were failing due to an update on `positionRouterAdmin`