### PR TITLE
ci: pin huff and foundry versions

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -15,7 +15,7 @@ jobs:
       - name: Install Foundry
         uses: foundry-rs/foundry-toolchain@v1
         with:
-          version: nightly
+          version: nightly-7398b65e831f2339d1d0a0bb05ade799e4f9d01e
 
       - name: Install Huff
         uses: huff-language/huff-toolchain@v3

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -18,9 +18,9 @@ jobs:
           version: nightly
 
       - name: Install Huff
-        uses: huff-language/huff-toolchain@v2
+        uses: huff-language/huff-toolchain@v3
         with:
-          version: nightly
+          version: nightly-d4638680736ad104290bc7a28542c058a18debf4
 
       - name: Install Solidity compiler
         uses: pontem-network/get-solc@master

--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ Deployed at `0xCB70efa43300Cd9B7eF4ed2087ceA7f7f6f3c195` on:
 ## Getting Started
 
 You will need:
-* [Huff](https://docs.huff.sh/get-started/installing/)
+* [Huff](https://docs.huff.sh/get-started/installing/) (`huffc 0.3.0` / `nightly-d4638680736ad104290bc7a28542c058a18debf4`)
 * [Foundry/Forge](https://github.com/foundry-rs/foundry)
 
 You can find `easm`, the basic EVM assembly compiler that is used to compile tests [here](https://github.com/oguimbal/EVM-Assembler).  

--- a/README.md
+++ b/README.md
@@ -125,7 +125,7 @@ Deployed at `0xCB70efa43300Cd9B7eF4ed2087ceA7f7f6f3c195` on:
 
 You will need:
 * [Huff](https://docs.huff.sh/get-started/installing/) (`huffc 0.3.0` / `nightly-d4638680736ad104290bc7a28542c058a18debf4`)
-* [Foundry/Forge](https://github.com/foundry-rs/foundry)
+* [Foundry/Forge](https://github.com/foundry-rs/foundry) (`nightly-7398b65e831f2339d1d0a0bb05ade799e4f9d01e`)
 
 You can find `easm`, the basic EVM assembly compiler that is used to compile tests [here](https://github.com/oguimbal/EVM-Assembler).  
 You can use [pyevmasm](https://github.com/crytic/pyevmasm) to disassemble bytecode.

--- a/README.md
+++ b/README.md
@@ -106,6 +106,10 @@ Thus, the actual memory of the host is starting at either 0x340 or 0x460 dependi
 ⚠️ The HyVM skips `jumpdest` (0x5B) validations that might appear in `push` opcodes values. This is OK if the executed bytecode is well formed (for instance, if you compiled it using `solc` or equivalent). But if you feed broken bytecode to the HyVM, this could lead to some discrepancies between the HyVM and the actual EVM behaviour.  
 There is an open issue to implement the validation if needed [here](https://github.com/oguimbal/HyVM/issues/16).
 
+## Note
+There is a workaround in the constructor to take into account a compiler bug.  
+It was raised in this [issue](https://github.com/huff-language/huff-rs/issues/238).
+
 ## Addresses
 
 Deployed at `0xCB70efa43300Cd9B7eF4ed2087ceA7f7f6f3c195` on:

--- a/test/forked/GMX.fork.t.sol
+++ b/test/forked/GMX.fork.t.sol
@@ -23,7 +23,7 @@ contract GMXTest is Test {
     // PositionRouter
     IGMXPositionRouter positionRouter = IGMXPositionRouter(0xb87a436B93fFE9D75c5cFA7bAcFff96430b09868);
     // Admin of the Position Router
-    address positionRouterAdmin = address(0x5F799f365Fa8A2B60ac0429C48B153cA5a6f0Cf8);
+    address positionRouterAdmin = address(0xB4d2603B2494103C90B2c607261DD85484b49eF0);
 
     //  =====   Set up  =====
     function setUp() public {


### PR DESCRIPTION
Document workaround and pin `huffc` version in CI to match local version