### PR TITLE
chore: pin block by test

### DIFF
--- a/foundry.toml
+++ b/foundry.toml
@@ -10,7 +10,6 @@ remappings = [
   "forge-std=lib/forge-std/src/",
   "foundry-huff=lib/foundry-huff/src/",
 ]
-fork_block_number = 17024124 # pin block number for forked tests
 
 [profile.default.rpc_endpoints]
 eth = 'https://eth-mainnet.g.alchemy.com/v2/${ALCHEMY_KEY}'

--- a/test/forked/Aave.fork.t.sol
+++ b/test/forked/Aave.fork.t.sol
@@ -21,7 +21,7 @@ contract AaveTests is Test {
     ILendingPool lendingPool = ILendingPool(0x7d2768dE32b0b80b7a3454c06BdAc94A69DDc7A9);
 
     function setUp() public {
-        vm.createSelectFork(vm.rpcUrl("eth"));
+        vm.createSelectFork(vm.rpcUrl("eth"), 18868834);
         owner = address(this);
         hyvm = HuffDeployer.config().with_evm_version("paris").deploy("HyVM");
         callHyvm = new CallHyvm();

--- a/test/forked/DoubleSwap.fork.t.sol
+++ b/test/forked/DoubleSwap.fork.t.sol
@@ -21,7 +21,7 @@ contract DoubleSwapTests is Test {
     bytes doubleswapHyvmBytecode;
 
     function setUp() public {
-        vm.createSelectFork(vm.rpcUrl("eth"));
+        vm.createSelectFork(vm.rpcUrl("eth"), 18868834);
         owner = address(this);
         hyvm = HuffDeployer.config().with_evm_version("paris").deploy("HyVM");
         callHyvm = new CallHyvm();

--- a/test/forked/GMX.fork.t.sol
+++ b/test/forked/GMX.fork.t.sol
@@ -27,7 +27,7 @@ contract GMXTest is Test {
 
     //  =====   Set up  =====
     function setUp() public {
-        vm.createSelectFork(vm.rpcUrl("arbi"));
+        vm.createSelectFork(vm.rpcUrl("arbi"), 163870012);
         owner = address(this);
         hyvm = HuffDeployer.config().with_evm_version("paris").deploy("HyVM");
         callHyvm = new CallHyvm();

--- a/test/forked/Morpho.fork.t.sol
+++ b/test/forked/Morpho.fork.t.sol
@@ -21,7 +21,7 @@ contract MorphoTests is Test {
     ILens lens = ILens(0x930f1b46e1D081Ec1524efD95752bE3eCe51EF67);
 
     function setUp() public {
-        vm.createSelectFork(vm.rpcUrl("eth"));
+        vm.createSelectFork(vm.rpcUrl("eth"), 18868834);
         owner = address(this);
         hyvm = HuffDeployer.config().with_evm_version("paris").deploy("HyVM");
         callHyvm = new CallHyvm();

--- a/test/forked/limits/Absurd.t.sol
+++ b/test/forked/limits/Absurd.t.sol
@@ -19,7 +19,7 @@ contract LimitSwapsTest is Test {
 
     //  =====   Set up  =====
     function setUp() public {
-        vm.createSelectFork(vm.rpcUrl("eth"));
+        vm.createSelectFork(vm.rpcUrl("eth"), 18868834);
         owner = address(this);
         hyvm = HuffDeployer.config().with_evm_version("paris").deploy("HyVM");
         callHyvm = new CallHyvm();

--- a/test/forked/limits/Jumps.t.sol
+++ b/test/forked/limits/Jumps.t.sol
@@ -19,7 +19,7 @@ contract LimitSwapsTest is Test {
 
     //  =====   Set up  =====
     function setUp() public {
-        vm.createSelectFork(vm.rpcUrl("eth"));
+        vm.createSelectFork(vm.rpcUrl("eth"), 18868834);
         owner = address(this);
         hyvm = HuffDeployer.config().with_evm_version("paris").deploy("HyVM");
         callHyvm = new CallHyvm();

--- a/test/forked/limits/Swaps.t.sol
+++ b/test/forked/limits/Swaps.t.sol
@@ -30,7 +30,7 @@ contract LimitSwapsTest is Test {
 
     //  =====   Set up  =====
     function setUp() public {
-        vm.createSelectFork(vm.rpcUrl("eth"));
+        vm.createSelectFork(vm.rpcUrl("eth"), 18868834);
         owner = address(this);
         hyvm = HuffDeployer.config().with_evm_version("paris").deploy("HyVM");
         callHyvm = new CallHyvm();


### PR DESCRIPTION
The pin of blocks in foundry.toml affects scripts. It was also not taking into account the different chains. Now the pin of block is done in each forked test.